### PR TITLE
Added support to domain delegation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pubspec.lock
 packages
+.idea/
+*.iml

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -103,6 +103,9 @@ class ServiceAccountCredentials {
   /// Private key as an [RSAPrivateKey].
   final RSAPrivateKey privateRSAKey;
 
+  /// For delegating access.
+  final String userEmail;
+
   /// Creates a new [ServiceAccountCredentials] from JSON.
   ///
   /// [json] can be either a [Map] or a JSON map encoded as a [String].
@@ -117,6 +120,7 @@ class ServiceAccountCredentials {
     var privateKey = json['private_key'];
     var email = json['client_email'];
     var type = json['type'];
+    var userEmail = json['user_email'];
 
     if (type != 'service_account') {
       throw new ArgumentError('The given credentials are not of type '
@@ -129,10 +133,10 @@ class ServiceAccountCredentials {
     }
 
     var clientId = new ClientId(identifier, null);
-    return new ServiceAccountCredentials(email, clientId, privateKey);
+    return new ServiceAccountCredentials(email, clientId, privateKey, userEmail: userEmail);
   }
 
-  ServiceAccountCredentials(this.email, this.clientId, String privateKey)
+  ServiceAccountCredentials(this.email, this.clientId, String privateKey, {this.userEmail})
       : privateKey = privateKey,
         privateRSAKey = keyFromString(privateKey) {
     if (email == null || clientId == null || privateKey == null) {

--- a/lib/auth_io.dart
+++ b/lib/auth_io.dart
@@ -139,9 +139,10 @@ Future<AutoRefreshingAuthClient> clientViaServiceAccount(
   }
 
   var flow = new JwtFlow(clientCredentials.email,
-                         clientCredentials.privateRSAKey,
-                         scopes,
-                         baseClient);
+                clientCredentials.privateRSAKey,
+                scopes,
+                baseClient,
+                userEmail: clientCredentials.userEmail);
   return flow.run().catchError((error, stack) {
     baseClient.close();
     return new Future.error(error, stack);

--- a/lib/src/oauth2_flows/jwt.dart
+++ b/lib/src/oauth2_flows/jwt.dart
@@ -28,9 +28,10 @@ class JwtFlow {
   final RS256Signer _signer;
   final List<String> _scopes;
   final http.Client _client;
+  final String _userEmail;
 
-  JwtFlow(this._clientEmail, RSAPrivateKey key, this._scopes, this._client)
-      : _signer = new RS256Signer(key);
+  JwtFlow(this._clientEmail, RSAPrivateKey key, this._scopes, this._client, {String userEmail})
+      : _signer = new RS256Signer(key), _userEmail = userEmail;
 
   Future<AccessCredentials> run() {
     int timestamp = new DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000
@@ -40,11 +41,12 @@ class JwtFlow {
 
     jwtClaimSet() {
       return {
-        'iss' : _clientEmail,
-        'scope' :  _scopes.join(' '),
-        'aud' : GOOGLE_OAUTH2_TOKEN_URL,
-        'exp' : timestamp + 3600 ,
-        'iat' : timestamp,
+          'iss' : _clientEmail,
+          'scope' : _scopes.join(' '),
+          'aud' : GOOGLE_OAUTH2_TOKEN_URL,
+          'exp' : timestamp + 3600,
+          'iat' : timestamp,
+          'sub': _userEmail
       };
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 0.2.2-1
+version: 0.2.3
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 0.2.2
+version: 0.2.2-1
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth

--- a/test/oauth2_flows/jwt_test.dart
+++ b/test/oauth2_flows/jwt_test.dart
@@ -45,11 +45,12 @@ main() {
 
   group('jwt-flow', () {
     var clientEmail = 'a@b.com';
+    var userEmail = 'c@d.com';
     var scopes = ['s1', 's2'];
 
     test('successfull', () {
       var flow = new JwtFlow(clientEmail, TestPrivateKey, scopes,
-          mockClient(expectAsync(successfullSignRequest), expectClose: false));
+          mockClient(expectAsync(successfullSignRequest), expectClose: false), userEmail: userEmail);
 
       flow.run().then(expectAsync((AccessCredentials credentials) {
         expect(credentials.accessToken.data, equals('atok'));

--- a/test/oauth2_test.dart
+++ b/test/oauth2_test.dart
@@ -68,7 +68,8 @@ main() {
        "private_key": TestPrivateKeyString,
        "client_email": "a@b.com",
        "client_id": "myid",
-       "type": "service_account"
+       "type": "service_account",
+        "user_email": "c@d.com"
      };
 
     test('from-invalid-individual-params', () {
@@ -95,6 +96,7 @@ main() {
       expect(credentialsFromJson.clientId.identifier, equals('myid'));
       expect(credentialsFromJson.clientId.secret, isNull);
       expect(credentialsFromJson.privateKey, equals(TestPrivateKeyString));
+      expect(credentialsFromJson.userEmail, equals("c@d.com"));
     });
 
     test('from-json-map', () {
@@ -104,6 +106,7 @@ main() {
       expect(credentialsFromJson.clientId.identifier, equals('myid'));
       expect(credentialsFromJson.clientId.secret, isNull);
       expect(credentialsFromJson.privateKey, equals(TestPrivateKeyString));
+      expect(credentialsFromJson.userEmail, equals("c@d.com"));
     });
   });
 


### PR DESCRIPTION
The "sub" property has been added to the SystemAccountCredentials. It allows to access data inside a domain which belongs to different user.
Service account documentation: https://developers.google.com/accounts/docs/OAuth2ServiceAccount#callinganapi