### PR TITLE
Deprecate use of X-Google-Metadata-Request in favor new Metadata-Flavor header

### DIFF
--- a/lib/src/oauth2_flows/metadata_server.dart
+++ b/lib/src/oauth2_flows/metadata_server.dart
@@ -17,7 +17,7 @@ import '../../auth.dart';
 /// ComputeEngine VM. It will retrieve the current access token from the
 /// metadata server.
 class MetadataServerAuthorizationFlow {
-  static const _HEADERS = const { 'X-Google-Metadata-Request' : 'True' };
+  static const _HEADERS = const { 'Metadata-Flavor' : 'Google' };
   static const _SERVICE_ACCOUNT_URL_PREFIX =
       'http://metadata/computeMetadata/v1/instance/service-accounts';
 

--- a/test/oauth2_flows/metadata_server_test.dart
+++ b/test/oauth2_flows/metadata_server_test.dart
@@ -16,12 +16,15 @@ import '../test_utils.dart';
 
 main() {
   var apiUrl = 'http://metadata/computeMetadata/v1';
+  var apiHeaderKey = 'Metadata-Flavor';
+  var apiHeaderValue = 'Google';
   var tokenUrl = '$apiUrl/instance/service-accounts/default/token';
   var scopesUrl = '$apiUrl/instance/service-accounts/default/scopes';
 
   Future<Response> successfullAccessToken(Request request) {
     expect(request.method, equals('GET'));
     expect(request.url.toString(), equals(tokenUrl));
+    expect(request.headers[apiHeaderKey], equals(apiHeaderValue));
 
     var body = JSON.encode({
       'access_token' : 'atok',
@@ -34,6 +37,7 @@ main() {
   Future<Response> invalidAccessToken(Request request) {
     expect(request.method, equals('GET'));
     expect(request.url.toString(), equals(tokenUrl));
+    expect(request.headers[apiHeaderKey], equals(apiHeaderValue));
 
     var body = JSON.encode({
       // Missing 'expires_in' entry
@@ -46,6 +50,7 @@ main() {
   Future<Response> successfullScopes(Request request) {
     expect(request.method, equals('GET'));
     expect(request.url.toString(), equals(scopesUrl));
+    expect(request.headers[apiHeaderKey], equals(apiHeaderValue));
 
     return new Future.value(new Response('s1\ns2', 200));
   }


### PR DESCRIPTION
We are deprecating the use of the X-Google-Metadata-Request header in favor
of the latest header, Metadata-Flavor.

The transition is explained here:

https://cloud.google.com/compute/docs/metadata#transitioning