### PR TITLE
Update http dependency version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.2.5+2
+## 0.2.5+3
 
-* Include http 0.12.0 in allowed dependency range.
+- Support `package:http` `>=0.11.3+17 <0.13.0`.
 
 ## 0.2.5+2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.5+2
 
+* Include http 0.12.0 in allowed dependency range.
+
+## 0.2.5+2
+
 * Support Dart 2.
 
 ## 0.2.5+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 0.2.5+2
+version: 0.2.5+3
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   crypto: '>=0.9.2 <3.0.0'
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.3+17 <0.13.0'
 
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
This should allow fixing: https://github.com/grpc/grpc-dart/issues/125