### PR TITLE
Ignore script loading error after timeout

### DIFF
--- a/lib/src/oauth2_flows/implicit.dart
+++ b/lib/src/oauth2_flows/implicit.dart
@@ -71,7 +71,10 @@ class ImplicitFlow {
     script.src = '${gapiUrl}?onload=dartGapiLoaded';
     script.onError.first.then((errorEvent) {
       timeout.cancel();
-      completer.completeError(new Exception('Failed to load gapi library.'));
+      if (!completer.isCompleted) {
+        // script loading errors can still happen after timeouts
+        completer.completeError(new Exception('Failed to load gapi library.'));
+      }
     });
     html.document.body.append(script);
 


### PR DESCRIPTION
A script loading error can still happen after a timeout have resolved the completer. In this case we should just ignore the script loading error.