### PR TITLE
Initialize implicit browser flows statically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.8
+
+* Initialize implicit browser flows statically, allowing multiple ImplicitFlow
+  objects to initialize without trying to load the gapi JavaScript library
+  multiple times.
+
 ## 0.2.7
 
  - Support for specifying desired `ResponseType`, allowing applications to

--- a/lib/src/oauth2_flows/implicit.dart
+++ b/lib/src/oauth2_flows/implicit.dart
@@ -83,9 +83,8 @@ class ImplicitFlow {
           throw new StateError('gapi.auth not loaded.');
         }
       } catch (error, stack) {
-        completer.completeError(error, stack);
-      } finally {
         _pendingInitialization = null;
+        completer.completeError(error, stack);
       }
     };
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 0.2.7
+version: 0.2.8
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth

--- a/test/oauth2_flows/implicit/gapi_initialize_successful_test.dart
+++ b/test/oauth2_flows/implicit/gapi_initialize_successful_test.dart
@@ -14,8 +14,10 @@ main() {
 
   test('gapi-initialize-successful', () {
     var clientId = new auth.ClientId('a', 'b');
+    var clientId2 = new auth.ClientId('c', 'd');
     var scopes = ['scope1', 'scope2'];
 
     expect(auth.createImplicitBrowserFlow(clientId, scopes), completes);
+    expect(auth.createImplicitBrowserFlow(clientId2, scopes), completes);
   });
 }


### PR DESCRIPTION
Static-ize logic dealing with loading the gapi JS library.

A single application can have multiple RPC services that hit different Google APIs, meaning they'll have multiple ImplicitFlows with different client configurations.

However, these deal with loading the gapi JS library (which can only ever be loaded once) in a non-static way, so multiple flows can try to load the library simultaneously. When that happens, the Future fails with an 'already completed' error.

By keeping track of a static pending initialization of the flow, we can ensure the library's only ever loaded once, no matter how many flow objects there are.