### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/src/oauth2_flows/auth_code.dart
+++ b/lib/src/oauth2_flows/auth_code.dart
@@ -67,10 +67,8 @@ Future<AccessCredentials> obtainAccessCredentialsUsingCode(
   request.headers['content-type'] = CONTENT_TYPE_URLENCODED;
 
   var response = await client.send(request);
-  Map jsonMap = await utf8.decoder
-      .bind(response.stream)
-      .transform(json.decoder)
-      .first;
+  Map jsonMap =
+      await utf8.decoder.bind(response.stream).transform(json.decoder).first;
 
   var idToken = jsonMap['id_token'];
   var tokenType = jsonMap['token_type'];

--- a/lib/src/oauth2_flows/auth_code.dart
+++ b/lib/src/oauth2_flows/auth_code.dart
@@ -67,8 +67,8 @@ Future<AccessCredentials> obtainAccessCredentialsUsingCode(
   request.headers['content-type'] = CONTENT_TYPE_URLENCODED;
 
   var response = await client.send(request);
-  Map jsonMap = await response.stream
-      .transform(utf8.decoder)
+  Map jsonMap = await utf8.decoder
+      .bind(response.stream)
       .transform(json.decoder)
       .first;
 


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
