### PR TITLE
Look for GCE metadata host in environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.10
+ * Look for GCE metadata host in environment under `$GCE_METADATA_HOST`.
+
 ## 0.2.9
  * Prepare for [Uint8List SDK breaking change](Prepare for Uint8List SDK breaking change).
 

--- a/lib/src/oauth2_flows/metadata_server.dart
+++ b/lib/src/oauth2_flows/metadata_server.dart
@@ -6,6 +6,7 @@ library googleapis_auth.metadata_server_flow;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
@@ -16,11 +17,14 @@ import '../utils.dart';
 ///
 /// Using this class assumes that the current program is running a
 /// ComputeEngine VM. It will retrieve the current access token from the
-/// metadata server.
+/// metadata server, looking first for one set in the environment under
+/// `$GCE_METADATA_HOST`.
 class MetadataServerAuthorizationFlow {
   static const _HEADERS = const {'Metadata-Flavor': 'Google'};
-  static const _SERVICE_ACCOUNT_URL_PREFIX =
-      'http://metadata/computeMetadata/v1/instance/service-accounts';
+  static const _SERVICE_ACCOUNT_URL_INFIX =
+      'computeMetadata/v1/instance/service-accounts';
+  static const _DEFAULT_METADATA_HOST = "metadata";
+  static const _GCE_METADATA_HOST_ENV_VAR = "GCE_METADATA_HOST";
 
   final String email;
   final Uri _scopesUrl;
@@ -30,10 +34,14 @@ class MetadataServerAuthorizationFlow {
   factory MetadataServerAuthorizationFlow(http.Client client,
       {String email: 'default'}) {
     var encodedEmail = Uri.encodeComponent(email);
-    var scopesUrl =
-        Uri.parse('$_SERVICE_ACCOUNT_URL_PREFIX/$encodedEmail/scopes');
-    var tokenUrl =
-        Uri.parse('$_SERVICE_ACCOUNT_URL_PREFIX/$encodedEmail/token');
+
+    final metadataHost = Platform.environment[_GCE_METADATA_HOST_ENV_VAR] ??
+        _DEFAULT_METADATA_HOST;
+    final serviceAccountPrefix =
+        "http://$metadataHost/$_SERVICE_ACCOUNT_URL_INFIX";
+
+    var scopesUrl = Uri.parse('$serviceAccountPrefix/$encodedEmail/scopes');
+    var tokenUrl = Uri.parse('$serviceAccountPrefix/$encodedEmail/token');
     return new MetadataServerAuthorizationFlow._(
         client, email, scopesUrl, tokenUrl);
   }

--- a/test/oauth2_flows/metadata_server_test.dart
+++ b/test/oauth2_flows/metadata_server_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 library googleapis_auth.metadata_server;
 
 import 'dart:async';


### PR DESCRIPTION
This change updates the googleapis_auth dart package to look for the
metadata host first at $GCE_METADATA_HOST. This simplifies
integration testing with credentialed services and follows the suit of
golang and python who have implemented the same check
(e.g., https://github.com/googleapis/google-cloud-go/blob/1310e431bb0f7a8662a328dab8983aee4c5869e4/compute/metadata/metadata.go#L41-L46).