### PR TITLE
Fix bugs that allowed for multiple completer.complete() calls.

### DIFF
--- a/lib/src/oauth2_flows/implicit.dart
+++ b/lib/src/oauth2_flows/implicit.dart
@@ -84,7 +84,9 @@ class ImplicitFlow {
         }
       } catch (error, stack) {
         _pendingInitialization = null;
-        completer.completeError(error, stack);
+        if (!completer.isCompleted) {
+          completer.completeError(error, stack);
+        }
       }
     };
 
@@ -184,6 +186,7 @@ class ImplicitFlow {
             if (code == null) {
               completer.completeError(new Exception('Expected to get auth code '
                   'from server in hybrid flow, but did not.'));
+              return;
             }
             completer.complete(new LoginResult(credentials, code: code));
           } else {


### PR DESCRIPTION
In some cases completer.complete() could be called more than once, which throws an exception.