### PR TITLE
Add ADC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.12
+ * Add `clientViaApplicationDefaultCredentials` for obtaining credentials using
+   [ADC](https://cloud.google.com/docs/authentication/production).
+
 ## 0.2.11+1
  * Fix 'multiple completer completion' bug in `ImplicitFlow`.
 

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -221,6 +221,9 @@ AuthClient authenticatedClient(
 /// Closing the returned [Client] will not close [baseClient].
 AutoRefreshingAuthClient autoRefreshingClient(
     ClientId clientId, AccessCredentials credentials, Client baseClient) {
+  if (credentials.accessToken.type != 'Bearer') {
+    throw new ArgumentError('Only Bearer access tokens are accepted.');
+  }
   if (credentials.refreshToken == null) {
     throw new ArgumentError('Refresh token in AccessCredentials was `null`.');
   }

--- a/lib/src/adc_utils.dart
+++ b/lib/src/adc_utils.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'dart:convert';
+import 'dart:async';
+
+import 'package:http/http.dart';
+
+import 'auth_http_utils.dart';
+import '../auth_io.dart';
+
+Future<AutoRefreshingAuthClient> fromApplicationsCredentialsFile(
+  File file,
+  String fileSource,
+  List<String> scopes,
+  Client baseClient,
+) async {
+  var credentials;
+  try {
+    credentials = json.decode(await file.readAsString());
+  } on IOException {
+    throw Exception(
+      'Failed to read credentials file from $fileSource',
+    );
+  } on FormatException {
+    throw Exception(
+      'Failed to parse JSON from credentials file from $fileSource',
+    );
+  }
+
+  if (credentials is Map && credentials['type'] == 'authorized_user') {
+    final clientId = ClientId(
+      credentials['client_id'],
+      credentials['client_secret'],
+    );
+    return AutoRefreshingClient(
+      baseClient,
+      clientId,
+      await refreshCredentials(
+        clientId,
+        AccessCredentials(
+          // Hack: Create empty credentials that have expired.
+          AccessToken('Bearer', '', DateTime(0).toUtc()),
+          credentials['refresh_token'],
+          scopes,
+        ),
+        baseClient,
+      ),
+      quotaProject: credentials["quota_project_id"],
+    );
+  }
+  return await clientViaServiceAccount(
+    ServiceAccountCredentials.fromJson(credentials),
+    scopes,
+    baseClient: baseClient,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: googleapis_auth
-version: 0.2.11+1
+version: 0.2.12
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth
@@ -9,6 +9,7 @@ environment:
 dependencies:
   crypto: '>=0.9.2 <3.0.0'
   http: '>=0.11.3+17 <0.13.0'
+  path: ^1.6.2
 
 dev_dependencies:
   test: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   crypto: '>=0.9.2 <3.0.0'
   http: '>=0.11.3+17 <0.13.0'
-  path: ^1.6.2
 
 dev_dependencies:
   test: ^1.3.0

--- a/test/adc_test.dart
+++ b/test/adc_test.dart
@@ -1,0 +1,120 @@
+@TestOn("vm")
+library googleapis_auth.adc_test;
+
+import 'dart:io';
+import 'dart:convert';
+import 'package:googleapis_auth/src/adc_utils.dart'
+    show fromApplicationsCredentialsFile;
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+main() {
+  test('fromApplicationsCredentialsFile', () async {
+    final tmp = await Directory.systemTemp.createTemp('googleapis_auth-test');
+    try {
+      final credsFile = File.fromUri(tmp.uri.resolve('creds.json'));
+      await credsFile.writeAsString(json.encode({
+        "client_id": "id",
+        "client_secret": "secret",
+        "refresh_token": "refresh",
+        "type": "authorized_user"
+      }));
+      final c = await fromApplicationsCredentialsFile(
+        credsFile,
+        'test-credentials-file',
+        [],
+        mockClient((Request request) async {
+          final url = request.url.toString();
+          if (url == 'https://accounts.google.com/o/oauth2/token') {
+            expect(request.method, equals('POST'));
+            expect(
+                request.body,
+                equals('client_id=id&'
+                    'client_secret=secret&'
+                    'refresh_token=refresh&'
+                    'grant_type=refresh_token'));
+            var body = jsonEncode({
+              'token_type': 'Bearer',
+              'access_token': 'atoken',
+              'expires_in': 3600,
+            });
+            return new Response(body, 200, headers: _jsonContentType);
+          }
+          if (url == 'https://storage.googleapis.com/b/bucket/o/obj') {
+            expect(request.method, equals('GET'));
+            expect(request.headers['Authorization'], equals('Bearer atoken'));
+            expect(request.headers['X-Goog-User-Project'], isNull);
+            return new Response('hello world', 200);
+          }
+          return Response('bad', 404);
+        }, expectClose: false),
+      );
+      expect(c.credentials.accessToken.data, equals('atoken'));
+
+      final r = await c.get('https://storage.googleapis.com/b/bucket/o/obj');
+      expect(r.statusCode, equals(200));
+      expect(r.body, equals('hello world'));
+
+      c.close();
+    } finally {
+      await tmp.delete(recursive: true);
+    }
+  });
+
+  test('fromApplicationsCredentialsFile w. quota_project_id', () async {
+    final tmp = await Directory.systemTemp.createTemp('googleapis_auth-test');
+    try {
+      final credsFile = File.fromUri(tmp.uri.resolve('creds.json'));
+      await credsFile.writeAsString(json.encode({
+        "client_id": "id",
+        "client_secret": "secret",
+        "refresh_token": "refresh",
+        "type": "authorized_user",
+        "quota_project_id": "project"
+      }));
+      final c = await fromApplicationsCredentialsFile(
+        credsFile,
+        'test-credentials-file',
+        [],
+        mockClient((Request request) async {
+          final url = request.url.toString();
+          if (url == 'https://accounts.google.com/o/oauth2/token') {
+            expect(request.method, equals('POST'));
+            expect(
+                request.body,
+                equals('client_id=id&'
+                    'client_secret=secret&'
+                    'refresh_token=refresh&'
+                    'grant_type=refresh_token'));
+            var body = jsonEncode({
+              'token_type': 'Bearer',
+              'access_token': 'atoken',
+              'expires_in': 3600,
+            });
+            return new Response(body, 200, headers: _jsonContentType);
+          }
+          if (url == 'https://storage.googleapis.com/b/bucket/o/obj') {
+            expect(request.method, equals('GET'));
+            expect(request.headers['Authorization'], equals('Bearer atoken'));
+            expect(request.headers['X-Goog-User-Project'], equals('project'));
+            return new Response('hello world', 200);
+          }
+          return Response('bad', 404);
+        }, expectClose: false),
+      );
+      expect(c.credentials.accessToken.data, equals('atoken'));
+
+      final r = await c.get('https://storage.googleapis.com/b/bucket/o/obj');
+      expect(r.statusCode, equals(200));
+      expect(r.body, equals('hello world'));
+
+      c.close();
+    } finally {
+      await tmp.delete(recursive: true);
+    }
+  });
+}
+
+final _jsonContentType = const {'content-type': 'application/json'};


### PR DESCRIPTION
Copying most of what the golang client is doing;
https://godoc.org/golang.org/x/oauth2/google#FindDefaultCredentials

There might be some tricks around using the metadata set by `gcloud auth application-default set-quota-project`, see:
https://cloud.google.com/sdk/gcloud/reference/auth/application-default/set-quota-project

But from what I can see, the golang doesn't have any special handling for this yet.