### PR TITLE
Require at-least Dart 2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth
 environment:
-  sdk: '>=2.0.0-dev.56.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   crypto: '>=0.9.2 <3.0.0'


### PR DESCRIPTION
This is now a requirement to publish non-pre-releases on `pub.dev`.