### PR TITLE
Remove unused async imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.12+1
+
+ * Removed a `dart:async` import that isn't required for \>=Dart 2.1.
+ * Require \>=Dart 2.1.
+
 ## 0.2.12
  * Add `clientViaApplicationDefaultCredentials` for obtaining credentials using
    [ADC](https://cloud.google.com/docs/authentication/production).

--- a/lib/auth_io.dart
+++ b/lib/auth_io.dart
@@ -5,7 +5,6 @@
 library googleapis_auth.auth_io;
 
 import 'dart:io';
-import 'dart:async';
 
 import 'package:http/http.dart';
 

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -4,8 +4,6 @@
 
 library googleapis_auth.typedefs;
 
-import 'dart:async';
-
 /// Function for directing the user or it's user-agent to [uri].
 ///
 /// The user is required to go to [uri] and either approve or decline the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: googleapis_auth
-version: 0.2.12
+version: 0.2.12+1
 author: Dart Team <misc@dartlang.org>
 description: Obtain Access credentials for Google services using OAuth 2.0
 homepage: https://github.com/dart-lang/googleapis_auth
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   crypto: '>=0.9.2 <3.0.0'


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.
Alternatively, if this package must continue to support 2.0, we will
have to add an exception for this internally.