### PR TITLE
Pass a Uri to package:http APIs

### DIFF
--- a/test/adc_test.dart
+++ b/test/adc_test.dart
@@ -53,7 +53,8 @@ main() {
       );
       expect(c.credentials.accessToken.data, equals('atoken'));
 
-      final r = await c.get('https://storage.googleapis.com/b/bucket/o/obj');
+      final r =
+          await c.get(Uri.https('storage.googleapis.com', '/b/bucket/o/obj'));
       expect(r.statusCode, equals(200));
       expect(r.body, equals('hello world'));
 
@@ -106,7 +107,8 @@ main() {
       );
       expect(c.credentials.accessToken.data, equals('atoken'));
 
-      final r = await c.get('https://storage.googleapis.com/b/bucket/o/obj');
+      final r =
+          await c.get(Uri.https('storage.googleapis.com', '/b/bucket/o/obj'));
       expect(r.statusCode, equals(200));
       expect(r.body, equals('hello world'));
 


### PR DESCRIPTION
Prepare for https://github.com/dart-lang/http/issues/375

This was fixed in #86 for one test but missed here since this file had
not yet been imported to google3 when I looked for cases.